### PR TITLE
Update styles structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Data contains everything to do with external requests, api calls. Everything tha
 
 [Interfaces](https://www.typescriptlang.org/docs/handbook/2/objects.html) contains both our **internal** and **server** interfaces. Internal interfaces are only used for items in our frontend, while server interfaces contain both **requests** (what we're going to send the backend) and **responses** (what we're going to receive from the backend).
 
-Styles contains our global style files that should be made available across our whole application, and our individual component styles.
+Styles contains our global style files that should be made available across our whole application. Individual component styles are kept alongside their TSX file.
 
 Utils are for handy functions that are available project-wide, these should have good descriptive names so other developers can quickly check whether the function they're looking for exists.
 

--- a/src/components/button/Button.tsx
+++ b/src/components/button/Button.tsx
@@ -1,4 +1,5 @@
 import classname from "classnames";
+import "./_button.scss";
 
 interface ButtonProps {
   className?: string;

--- a/src/components/button/_button.scss
+++ b/src/components/button/_button.scss
@@ -1,3 +1,6 @@
+@use "../../styles/mixins" as *;
+@use "../../styles/variables" as *;
+
 .button {
   @include focus-outline;
 

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -1,3 +1,5 @@
+import "./_layout.scss";
+
 interface LayoutProps {
   exampleProp?: boolean;
 }

--- a/src/components/layout/_layout.scss
+++ b/src/components/layout/_layout.scss
@@ -1,3 +1,5 @@
+@use "../../styles/variables" as *;
+
 .layout {
   min-height: 100vh;
   width: 100vw;

--- a/src/styles/global.scss
+++ b/src/styles/global.scss
@@ -1,3 +1,5 @@
+@use "./variables" as *;
+
 * {
   color: $text-color;
 }

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -1,10 +1,3 @@
-// general imports
-@import "./reset.scss";
-@import "./variables.scss";
-@import "./typography.scss";
-@import "./global.scss";
-@import "./mixins.scss";
-
-// component styles
-@import "./components/layout";
-@import "./components/button";
+@use "./reset.scss" as *;
+@use "./typography.scss" as *;
+@use "./global.scss" as *;

--- a/src/styles/mixins.scss
+++ b/src/styles/mixins.scss
@@ -1,3 +1,5 @@
+@use "./variables" as *;
+
 @mixin focus-outline {
   &:focus {
     outline: 0.188rem $outline-color solid;

--- a/src/styles/typography.scss
+++ b/src/styles/typography.scss
@@ -1,3 +1,5 @@
+@use "./variables" as *;
+
 // here we use rem for font-size
 // rem is relative to the :root element in the dom (html tag)
 // conversely em is relative to the parent's font-size


### PR DESCRIPTION
- SCSS is now contained within component folders
- SCSS now using@use instead of @import as it's being [deprecated ](https://sass-lang.com/documentation/at-rules/import)